### PR TITLE
remove broken links in table of contents for functor-monad tutorial

### DIFF
--- a/haskell/Functors__Monads__Applicatives_and_Monoids.md
+++ b/haskell/Functors__Monads__Applicatives_and_Monoids.md
@@ -32,8 +32,6 @@
     - [IO Examples](#io-examples)
     - [Sources](#sources-1)
   - [State Monad](#state-monad)
-- [--   runState :: (\s -> (a, s)) -> s -> (a, s)](#-----runstate--%5Cs---a-s---s---a-s)
-- [--  => ((), 5) ](#------5)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
Looks like they got added by accident somehow
